### PR TITLE
Fix WebLogic not supporting more parallel connections

### DIFF
--- a/weblogic/modules/src/main/java/org/atmosphere/weblogic/AtmosphereWebLogicServlet.java
+++ b/weblogic/modules/src/main/java/org/atmosphere/weblogic/AtmosphereWebLogicServlet.java
@@ -30,9 +30,12 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import java.io.IOException;
 
- /**
-  * WebLogic Comet implementation.
-  */
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResponse;
+
+/**
+ * WebLogic Comet implementation.
+ */
 public class AtmosphereWebLogicServlet extends AbstractAsyncServlet {
 
     protected static final Logger logger = LoggerFactory.getLogger(AtmosphereServlet.class);
@@ -88,8 +91,10 @@ public class AtmosphereWebLogicServlet extends AbstractAsyncServlet {
      */
     protected boolean doRequest(RequestResponseKey rrk) throws IOException, ServletException {
         try {
-            rrk.getRequest().getSession().setAttribute(WebLogicCometSupport.RRK, rrk);
-            Action action = framework.doCometSupport(AtmosphereRequestImpl.wrap(rrk.getRequest()), AtmosphereResponseImpl.wrap(rrk.getResponse()));
+            AtmosphereRequest req = AtmosphereRequestImpl.wrap(rrk.getRequest());
+            AtmosphereResponse resp = AtmosphereResponseImpl.wrap(rrk.getResponse());
+            Action action = framework.doCometSupport(req , resp);
+            rrk.getRequest().getSession().setAttribute(WebLogicCometSupport.RRK + resp.uuid(), rrk);
             if (action.type() == Action.TYPE.SUSPEND) {
                 if (action.timeout() == -1) {
                     rrk.setTimeout(Integer.MAX_VALUE);

--- a/weblogic/modules/src/main/java/org/atmosphere/weblogic/WebLogicCometSupport.java
+++ b/weblogic/modules/src/main/java/org/atmosphere/weblogic/WebLogicCometSupport.java
@@ -76,7 +76,7 @@ public class WebLogicCometSupport extends AsynchronousProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(WebLogicCometSupport.class);
 
-    public static final String RRK = "RequestResponseKey";
+    public static final String RRK = "RequestResponseKey-";
 
     public WebLogicCometSupport(AtmosphereConfig config) {
         super(config);
@@ -109,7 +109,7 @@ public class WebLogicCometSupport extends AsynchronousProcessor {
         super.action(actionEvent);
         if (actionEvent.isInScope() && actionEvent.action().type() == Action.TYPE.RESUME) {
             try {
-                RequestResponseKey rrk = (RequestResponseKey) actionEvent.getRequest().getSession().getAttribute(RRK);
+                RequestResponseKey rrk = (RequestResponseKey) actionEvent.getRequest().getSession().getAttribute(RRK + actionEvent.uuid());
                 AbstractAsyncServlet.notify(rrk, null);
             } catch (IOException ex) {
                 logger.debug("action failed", ex);


### PR DESCRIPTION
Storing RequestResponseKey in conjunction with tracking ID allow to store more keys within one http session.